### PR TITLE
Use Granite.MessageDialog instead of Gtk.MessageDialog

### DIFF
--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -36,7 +36,7 @@ namespace Timetable {
 
         public Gtk.FileChooserDialog create_file_chooser (string title,
                 Gtk.FileChooserAction action) {
-            var chooser = new Gtk.FileChooserDialog (title, null, action);
+            var chooser = new Gtk.FileChooserDialog (title, this, action);
 
             chooser.add_button (_("_Cancel"), Gtk.ResponseType.CANCEL);
             if (action == Gtk.FileChooserAction.OPEN) {

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -1,18 +1,23 @@
 namespace Timetable {
-    public class Dialog : Gtk.MessageDialog {
-        public Dialog.display_save_confirm (Gtk.Window parent) {
-            set_markup ("<b>" +
-                    _("There are unsaved changes to the timetable. Do you want to save?") + "</b>" +
-                    "\n\n" + _("If you don't save, changes will be lost forever."));
-            use_markup = true;
-            type_hint = Gdk.WindowTypeHint.DIALOG;
-            set_transient_for (parent);
+    public class Dialog : Granite.MessageDialog {
+        public Dialog (Gtk.Window parent) {
+            Object (
+                primary_text: _("Do You Want to Save Changes to the Timetable?"),
+                secondary_text: _("If you don't save, changes will be lost forever."),
+                image_icon: new ThemedIcon ("dialog-warning"),
+                transient_for: parent,
+                modal: true
+            );
+        }
 
-            var button = new Gtk.Button.with_label (_("Don't Save"));
-            button.show ();
-            add_action_widget (button, Gtk.ResponseType.NO);
-            add_button ("_Save", Gtk.ResponseType.YES);
-            message_type = Gtk.MessageType.INFO;
+        public void display_save_confirm () {
+            var discard_button = new Gtk.Button.with_label (_("Don't Save"));
+            add_action_widget (discard_button, Gtk.ResponseType.NO);
+            var save_button = new Gtk.Button.with_label (_("Save"));
+            save_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+            add_action_widget (save_button, Gtk.ResponseType.YES);
+
+            show_all ();
         }
 
         public File display_save_dialog () {

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -2,7 +2,7 @@ namespace Timetable {
     public class Dialog : Granite.MessageDialog {
         public Dialog (Gtk.Window parent) {
             Object (
-                primary_text: _("Do You Want to Save Changes to the Timetable?"),
+                primary_text: _("Save Changes to the Timetable?"),
                 secondary_text: _("If you don't save, changes will be lost forever."),
                 image_icon: new ThemedIcon ("dialog-warning"),
                 transient_for: parent,

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -10,7 +10,7 @@ namespace Timetable {
             );
         }
 
-        public void display_save_confirm () {
+        construct {
             var discard_button = new Gtk.Button.with_label (_("Don't Save"));
             add_action_widget (discard_button, Gtk.ResponseType.NO);
             var cancel_button = new Gtk.Button.with_label (_("Cancel"));
@@ -18,8 +18,6 @@ namespace Timetable {
             var save_button = new Gtk.Button.with_label (_("Save"));
             save_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             add_action_widget (save_button, Gtk.ResponseType.YES);
-
-            show_all ();
         }
 
         public File display_save_dialog () {

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -38,11 +38,11 @@ namespace Timetable {
                 Gtk.FileChooserAction action) {
             var chooser = new Gtk.FileChooserDialog (title, null, action);
 
-            chooser.add_button ("_Cancel", Gtk.ResponseType.CANCEL);
+            chooser.add_button (_("_Cancel"), Gtk.ResponseType.CANCEL);
             if (action == Gtk.FileChooserAction.OPEN) {
-                chooser.add_button ("_Open", Gtk.ResponseType.ACCEPT);
+                chooser.add_button (_("_Open"), Gtk.ResponseType.ACCEPT);
             } else if (action == Gtk.FileChooserAction.SAVE) {
-                chooser.add_button ("_Save", Gtk.ResponseType.ACCEPT);
+                chooser.add_button (_("_Save"), Gtk.ResponseType.ACCEPT);
                 chooser.set_do_overwrite_confirmation (true);
             }
 

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -17,7 +17,10 @@ namespace Timetable {
             add_action_widget (cancel_button, Gtk.ResponseType.CANCEL);
             var save_button = new Gtk.Button.with_label (_("Save"));
             save_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+            save_button.can_default = true;
             add_action_widget (save_button, Gtk.ResponseType.YES);
+
+            set_default (save_button);
         }
 
         public File display_save_dialog () {

--- a/src/Services/DialogServices.vala
+++ b/src/Services/DialogServices.vala
@@ -13,6 +13,8 @@ namespace Timetable {
         public void display_save_confirm () {
             var discard_button = new Gtk.Button.with_label (_("Don't Save"));
             add_action_widget (discard_button, Gtk.ResponseType.NO);
+            var cancel_button = new Gtk.Button.with_label (_("Cancel"));
+            add_action_widget (cancel_button, Gtk.ResponseType.CANCEL);
             var save_button = new Gtk.Button.with_label (_("Save"));
             save_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             add_action_widget (save_button, Gtk.ResponseType.YES);

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -7,7 +7,6 @@ namespace Timetable.FileManager {
         debug ("New button pressed.");
         debug ("Buffer was modified. Asking user to save first.");
         dialog = new Dialog (win);
-        dialog.display_save_confirm ();
         dialog.response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.YES:
@@ -42,7 +41,7 @@ namespace Timetable.FileManager {
         });
 
         if (win.monday_column.is_modified == true || win.tuesday_column.is_modified == true || win.wednesday_column.is_modified == true || win.thursday_column.is_modified == true || win.friday_column.is_modified == true || win.weekend_column.is_modified == true) {
-            dialog.show ();
+            dialog.show_all ();
             win.monday_column.is_modified = false;
             win.tuesday_column.is_modified = false;
             win.wednesday_column.is_modified = false;

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -1,11 +1,13 @@
 namespace Timetable.FileManager {
     public MainWindow win;
     public File file;
+    public Dialog dialog;
 
     public void new_tt (MainWindow win) {
         debug ("New button pressed.");
         debug ("Buffer was modified. Asking user to save first.");
-        var dialog = new Dialog.display_save_confirm (win);
+        dialog = new Dialog (win);
+        dialog.display_save_confirm ();
         dialog.response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.YES:
@@ -59,7 +61,6 @@ namespace Timetable.FileManager {
 
     public void save_as (MainWindow win) throws Error {
         debug ("Save as button pressed.");
-        var dialog = new Dialog ();
         var file = dialog.display_save_dialog ();
 
         try {

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -1,12 +1,11 @@
 namespace Timetable.FileManager {
     public MainWindow win;
     public File file;
-    public Dialog dialog;
 
     public void new_tt (MainWindow win) {
         debug ("New button pressed.");
         debug ("Buffer was modified. Asking user to save first.");
-        dialog = new Dialog (win);
+        var dialog = new Dialog (win);
         dialog.response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.YES:
@@ -60,6 +59,7 @@ namespace Timetable.FileManager {
 
     public void save_as (MainWindow win) throws Error {
         debug ("Save as button pressed.");
+        var dialog = new Dialog (win);
         var file = dialog.display_save_dialog ();
 
         try {

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -4,7 +4,6 @@ namespace Timetable.FileManager {
 
     public void new_tt (MainWindow win) {
         debug ("New button pressed.");
-        debug ("Buffer was modified. Asking user to save first.");
         var dialog = new Dialog (win);
         dialog.response.connect ((response_id) => {
             switch (response_id) {
@@ -40,6 +39,7 @@ namespace Timetable.FileManager {
         });
 
         if (win.monday_column.is_modified == true || win.tuesday_column.is_modified == true || win.wednesday_column.is_modified == true || win.thursday_column.is_modified == true || win.friday_column.is_modified == true || win.weekend_column.is_modified == true) {
+            debug ("Buffer was modified. Asking user to save first.");
             dialog.show_all ();
             win.monday_column.is_modified = false;
             win.tuesday_column.is_modified = false;
@@ -47,6 +47,8 @@ namespace Timetable.FileManager {
             win.thursday_column.is_modified = false;
             win.friday_column.is_modified = false;
             win.weekend_column.is_modified = false;
+        } else {
+            debug ("Buffer was not modified. Aborting.");
         }
     }
 


### PR DESCRIPTION
## Before

![screenshot from 2018-10-28 12-09-57](https://user-images.githubusercontent.com/26003928/47612086-bf1c3500-dab6-11e8-9ccd-289b4c0472b5.png)

## After

![screenshot from 2018-10-28 22-42-00](https://user-images.githubusercontent.com/26003928/47616674-63c46400-db03-11e8-87f8-703fc67104bf.png)

## Changes Summary

* Use Granite.MessageDialog instead of Gtk.MessageDialog
* Add "Cancel" button in case users clicked the "New Timetable" button by mistake (Indeed we can cancel with `Esc` key, but I think we should clarify)
* Make buttons in the filechooser translatable

I'm worried that the "Save" button in the MessageDialog is not focused when the dialog is shown, because if users press `Enter` key wrongly without switching the focus, they should lose their timetable. But I'm not sure how to bring the focus to the "Save" button, would it be possible for you to tell me how?