### PR TITLE
Fix an existing file is not saved when we click the "New" button

### DIFF
--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -27,6 +27,7 @@ namespace Timetable.FileManager {
                     win.wednesday_column.clear_column ();
                     win.thursday_column.clear_column ();
                     win.friday_column.clear_column ();
+                    reset_modification_state (win);
                     break;
                 case Gtk.ResponseType.CANCEL:
                     debug ("User cancelled, don't do anything.");
@@ -41,12 +42,6 @@ namespace Timetable.FileManager {
         if (win.monday_column.is_modified == true || win.tuesday_column.is_modified == true || win.wednesday_column.is_modified == true || win.thursday_column.is_modified == true || win.friday_column.is_modified == true || win.weekend_column.is_modified == true) {
             debug ("Buffer was modified. Asking user to save first.");
             dialog.show_all ();
-            win.monday_column.is_modified = false;
-            win.tuesday_column.is_modified = false;
-            win.wednesday_column.is_modified = false;
-            win.thursday_column.is_modified = false;
-            win.friday_column.is_modified = false;
-            win.weekend_column.is_modified = false;
         } else {
             debug ("Buffer was not modified. Aborting.");
         }
@@ -102,6 +97,7 @@ namespace Timetable.FileManager {
                     var buffer = buffer_text;
                     uint8[] binbuffer = buffer.data;
                     save_file (file, binbuffer);
+                    reset_modification_state (win);
                 }
             }
         } catch (Error e) {
@@ -109,5 +105,14 @@ namespace Timetable.FileManager {
         }
 
         file = null;
+    }
+
+    public void reset_modification_state (MainWindow win) {
+        win.monday_column.is_modified = false;
+        win.tuesday_column.is_modified = false;
+        win.wednesday_column.is_modified = false;
+        win.thursday_column.is_modified = false;
+        win.friday_column.is_modified = false;
+        win.weekend_column.is_modified = false;
     }
 }


### PR DESCRIPTION
## Steps to reproduce the behavior

* Add some events to the timetable
* Click "New" button
* Click "Save" in the dialog and save the timetable with any name
* After the filechooserdialog is closed, check where you've saved the previous timetable; there is no timetable saved…

## Solution

Before saving the timetable, we have this condition:

https://github.com/lainsce/timetable/blob/b72fce896e3da6a0d7fc454fd53c3433d0cbea39/src/Services/FileManager.vala#L76

But that condition is not always met when it was called by clicking the "New" button, because columns of the timetable is always set as not modified soon after the dialog is shown:

https://github.com/lainsce/timetable/blob/b72fce896e3da6a0d7fc454fd53c3433d0cbea39/src/Services/FileManager.vala#L41-L49

To solve this problem, I create a new method, immigrate `is_modified` sentences into that method, and call that method after the saving process is done (thus user saves their timetable) and when user doesn't save their timetable.